### PR TITLE
Set zsh as default shell on Debian

### DIFF
--- a/chezmoi/.chezmoiscripts/debian/run_once_before_02_change_shell.sh
+++ b/chezmoi/.chezmoiscripts/debian/run_once_before_02_change_shell.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Set zsh as the default login shell (zsh is installed in 00_install_packages).
+if command -v zsh >/dev/null 2>&1; then
+  sudo chsh -s "$(command -v zsh)" "$(whoami)"
+fi


### PR DESCRIPTION
Adds a run-once base script for the Debian setup that sets zsh as the default login shell after it's installed.

- `chezmoi/.chezmoiscripts/debian/run_once_before_02_change_shell.sh` runs `sudo chsh -s "$(command -v zsh)" "$(whoami)"`, guarded so it no-ops if zsh isn't present.
- Lives in the Debian base folder, so it applies to every profile (minimal/homelab/ai-agent), after `00_install_packages` installs zsh.

Clean fast-forward on top of `master`.

https://claude.ai/code/session_01PP5K9wrutR4cntcbSy8ynQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PP5K9wrutR4cntcbSy8ynQ)_