### PR TITLE
omniwm: bind option+z to toggle full width

### DIFF
--- a/chezmoi/private_dot_config/omniwm/settings.toml
+++ b/chezmoi/private_dot_config/omniwm/settings.toml
@@ -682,7 +682,7 @@ binding = "Unassigned"
 id = "cycleWindowSecondarySpanBackward"
 
 [[hotkeys]]
-binding = "Option+Shift+F"
+binding = "Option+Z"
 id = "toggleContainerFullPrimarySpan"
 
 [[hotkeys]]


### PR DESCRIPTION
## Summary

- Rebinds OmniWM's `toggleContainerFullPrimarySpan` hotkey (the "toggle full width" action, since primary span = width in OmniWM's niri-style layout) from `Option+Shift+F` to `Option+Z`.

## Why

This matches the `alt-z` "toggle fullscreen/zoom" convention already used for the equivalent action in the yabai (`alt - z : yabai -m window --toggle zoom-fullscreen`) and AeroSpace (`alt-z = 'fullscreen'`) configs in this repo, keeping muscle memory consistent across window managers.

## Files changed

- `chezmoi/private_dot_config/omniwm/settings.toml`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gej4LHWp2x3PmmjoQrD9oR)_