### PR TITLE
karabiner: remap Option+W to Command+W (close window)

### DIFF
--- a/chezmoi/private_dot_config/karabiner.edn
+++ b/chezmoi/private_dot_config/karabiner.edn
@@ -49,6 +49,11 @@
         ; Esc -> Grave on Keychron
         {:des "Esc -> Grave" :rules [:keychron-k12 [:##escape :grave_accent_and_tilde]]}
 
+        ; OmniWM has no bindable "close window" action (only Overview mode has a
+        ; fixed, non-configurable Cmd+W). Remap Option+W -> Cmd+W globally so it
+        ; behaves like the old yabai/aerospace `alt-w = 'close'` binding.
+        {:des "Option+W -> Close Window (OmniWM)" :rules [[:!Ow :!Cw]]}
+
         ; General
         {:des "; <-> : (Colemak)" :rules [:colemak :colemakdh :colemakstd [:p :!Sp] [:!Sp :p]]}
 


### PR DESCRIPTION
## Summary

Adds a Karabiner remap so `Option+W` closes the focused window, matching the old `alt-w = 'close'` binding from the yabai/aerospace configs.

## Why not add this to OmniWM's `settings.toml` directly?

I checked OmniWM's source (v0.6.0, latest release as of writing). It has no bindable "close window" hotkey action at all:

- The `[[hotkeys]]` list in `settings.toml` only covers focus/move/workspace/layout actions (`HotkeyCommand` enum in `Sources/OmniWM/Core/Input/HotkeyCommand.swift` has no `close` case).
- The only close-window behavior anywhere in the app is inside Overview mode, where `Cmd+W` presses the AX close button on the selected window — but that binding is hardcoded and not exposed as a configurable hotkey, and only works while Overview is open.

So there's no `id` to bind `Option+W` to in the OmniWM config. Given that gap, this remaps `Option+W` → `Command+W` globally via Karabiner (`chezmoi/private_dot_config/karabiner.edn`), which is macOS's standard "Close Window" shortcut in virtually every app — the same practical effect as the old WM-level close bindings.

## Changes

- `chezmoi/private_dot_config/karabiner.edn`: new rule remapping `Option+W` → `Command+W`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf5eJhqgaK82Xr2cVHfxZ5)_